### PR TITLE
contig info for header is extracted from bam

### DIFF
--- a/conf/dkfz_cluster_37.config
+++ b/conf/dkfz_cluster_37.config
@@ -21,7 +21,7 @@ params {
     max_time   = '48.h'
 
     // Input data
-    input  = 'assets/samplesheet_cluster.csv'
+    input  = 'assets/samplesheet_test_37.csv'
 
     // workflow parameters
     outdir                     = "results"

--- a/subworkflows/local/output_standard_vcf.nf
+++ b/subworkflows/local/output_standard_vcf.nf
@@ -25,12 +25,13 @@ workflow OUTPUT_STANDARD_VCF {
     CREATE_CONTIGHEADER(
         sample_ch
     )
-    
+    vcf_ch.combine(CREATE_CONTIGHEADER.out.header, by:0)
+            .set{vcf_std}
     //
     // MODULE: CONVERT_TO_VCF
     //
     CONVERT_TO_VCF(
-        vcf_ch.join(CREATE_CONTIGHEADER.out.header),
+        vcf_std,
         config
     )
     versions = versions.mix(CONVERT_TO_VCF.out.versions)

--- a/subworkflows/local/output_standard_vcf.nf
+++ b/subworkflows/local/output_standard_vcf.nf
@@ -11,10 +11,9 @@ include { CREATE_CONTIGHEADER   } from '../../modules/local/create_contigheader.
 
 workflow OUTPUT_STANDARD_VCF {
     take:
-    vcf_ch // channel: [val(meta), vcf]
-    config // channel: [config.json]
-    ref    // reference channel [ref.fa, ref.fa.fai]
-
+    vcf_ch    // channel: [val(meta), vcf]
+    config    // channel: [config.json]
+    sample_ch // channel: [val(meta), tumor, tumor_bai, control, control_bai]
     
     main:
 
@@ -24,14 +23,14 @@ workflow OUTPUT_STANDARD_VCF {
     // CREATE_CONTIGHEADER
     //
     CREATE_CONTIGHEADER(
-        ref
+        sample_ch
     )
     
     //
     // MODULE: CONVERT_TO_VCF
     //
     CONVERT_TO_VCF(
-        vcf_ch.combine(CREATE_CONTIGHEADER.out.header),
+        vcf_ch.join(CREATE_CONTIGHEADER.out.header),
         config
     )
     versions = versions.mix(CONVERT_TO_VCF.out.versions)

--- a/workflows/platypusindelcalling.nf
+++ b/workflows/platypusindelcalling.nf
@@ -316,7 +316,7 @@ workflow PLATYPUSINDELCALLING {
         OUTPUT_STANDARD_VCF(
             ch_stdvcf,
             config,
-            ref
+            sample_ch
         )
         ch_versions = ch_versions.mix(OUTPUT_STANDARD_VCF.out.versions)
     }


### PR DESCRIPTION
contig info is extracted from tumor bam files instead of fasta.
samtools view -H is used to get contig info which is then converted into vcf header format using awk. 